### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/udawalpola/ec8b30a7-1d3c-4e46-88a4-b511b94c6504/896a426e-ad49-4bd5-a03e-dd58b4c4093e/_apis/work/boardbadge/4cb26122-00ee-4fc4-a1fd-5431c970afff)](https://dev.azure.com/udawalpola/ec8b30a7-1d3c-4e46-88a4-b511b94c6504/_boards/board/t/896a426e-ad49-4bd5-a03e-dd58b4c4093e/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/udawalpola/ec8b30a7-1d3c-4e46-88a4-b511b94c6504/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.